### PR TITLE
Update domain name references and shorten page titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 > _Want to give feedback on the documentation? [Open an issue on this repository](https://github.com/ministryofjustice/technical-architecture/issues)._
 
-This repository holds the website and documentation for the [Technical Architecture at the Ministry of Justice
-](https://ministryofjustice.github.io/technical-architecture) website.
+This repository holds the website and documentation for the [Technical Architecture](https://technical-architecture.service.justice.gov.uk/) website.
 
 This repository uses the Ministry of Justice's [template-documentation-site](https://github.com/ministryofjustice/template-documentation-site).
 

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -1,12 +1,12 @@
 # See the available options: https://tdt-documentation.london.cloudapps.digital/configure_project/global_configuration/#configure-your-documentation-site
 
 # Host to use for canonical URL generation (without trailing slash)
-host: https://ministryofjustice.github.io/technical-architecture
+host: https://technical-architecture.service.justice.gov.uk
 
 # Header-related options
 show_govuk_logo: false
-service_name: "Technical Architecture at the Ministry of Justice"
-service_link: /technical-architecture
+service_name: "Technical Architecture"
+service_link: /
 
 # Links to show on right-hand-side of header
 header_links:

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Technical Architecture at the Ministry of Justice
+title: Technical Architecture
 ---
 
 # <%= current_page.data.title %>


### PR DESCRIPTION
This PR:

- updates domain name references to [https://technical-architecture.service.justice.gov.uk](https://technical-architecture.service.justice.gov.uk) from [https://ministryofjustice.github.io/technical-architecture](https://ministryofjustice.github.io/technical-architecture) to support a custom domain in GitHub Pages
- shortens page titles from "Technical Architecture at the Ministry of Justice" to "Technical Architecture" for improved readability