### PR TITLE
Update link to domain naming standard

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -23,7 +23,7 @@ Reference documents listed here are publicly available outside the Ministry of J
   - [I want to take my device overseas](https://ministryofjustice.github.io/security-guidance/accessing-moj-it-systems-from-overseas/#accessing-ministry-of-justice-moj-it-systems-overseas)
 
 - [Ministry of Justice Technical Guidance](https://technical-guidance.service.justice.gov.uk/)
-  - [I want to request a domain name for my service](https://ministryofjustice.github.io/technical-guidance/documentation/standards/naming-domains.html#naming-domains)
+  - [I want to request a domain name for my service](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/services/domain-naming-standard.html)
   - [I want to use Git to maintain my service and documentation](https://ministryofjustice.github.io/technical-guidance/documentation/guides/using-git.html#using-git)
   - [I want to share and version any knowledge that is unique to me](https://ministryofjustice.github.io/technical-guidance/documentation/principles/development-principles.html#development-principles)
   - [I want to host a service in the cloud](https://technical-guidance.service.justice.gov.uk/documentation/standards/hosting.html)


### PR DESCRIPTION
## 👀 Purpose

- This PR updates the link to the new location for the MoJ Domain Naming Standard. All DNS related guidance is being co-located in the Operations Engineering User Guide.

## ♻️ What's changed

- Updated link to Domain Naming standard