### PR TITLE
Update link to using Git

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -24,7 +24,7 @@ Reference documents listed here are publicly available outside the Ministry of J
 
 - [Ministry of Justice Technical Guidance](https://technical-guidance.service.justice.gov.uk/)
   - [I want to request a domain name for my service](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/services/domain-naming-standard.html)
-  - [I want to use Git to maintain my service and documentation](https://ministryofjustice.github.io/technical-guidance/documentation/guides/using-git.html#using-git)
+  - [I want to use Git to maintain my service and documentation](https://user-guide.operations-engineering.service.justice.gov.uk/documentation/information/using-git.html)
   - [I want to share and version any knowledge that is unique to me](https://ministryofjustice.github.io/technical-guidance/documentation/principles/development-principles.html#development-principles)
   - [I want to host a service in the cloud](https://technical-guidance.service.justice.gov.uk/documentation/standards/hosting.html)
   - [I want to store my SSH key and other secrets 1Password](https://security-guidance.service.justice.gov.uk/using-1password/#using-1password)


### PR DESCRIPTION
## 👀 Purpose

- This PR updates the link to the new location for the Using Git guidance. All Git related guidance is being co-located in the Operations Engineering User Guide.

## ♻️ What's changed

- Updated link to Using Git